### PR TITLE
Add failing test for hybrid ipv4 notation

### DIFF
--- a/test/unittest.js
+++ b/test/unittest.js
@@ -94,11 +94,18 @@ describe( 'IPSet', function() {
         ips.add( '0203:119:0000::1/30', 'fail' );
         ips.add( '0203:123:0000::1/128', 'fail' );
 
+        ips.add( "::ffff:104.192.136.0/21", 'hybrid' );
+
         expect( ips.match( '1.2.3.3' ) ).to.equal( 'V4' );
         expect( ips.match( '2.2.3.3' ) ).to.be.undefined;
 
         expect( ips.match( '0203:123:0000::2' ) ).to.equal( 'V6' );
         expect( ips.match( '03::' ) ).to.be.undefined;
+
+        expect( ips.match( '::ffff:104.192.142.193' ) ).to.equal( 'hybrid' );
+        expect( ips.match( '104.192.142.193' ) ).to.equal( 'hybrid' );
+        expect( ips.match( '::ffff:127.0.0.1' ) ).to.be.undefined;
+        expect( ips.match( '127.0.0.1' ) ).to.be.undefined;
 
         expect( ips.match( ips.convertAddress( '1.2.3.3' ) ) ).to.equal( 'V4' );
         expect( ips.match( ips.convertAddress( '0203:123:0000::2' ) ) ).to.equal( 'V6' );


### PR DESCRIPTION
Hybrid IPv4 notation does not seem to be supported (`::ffff:127.0.0.1`) and with ranges too (e.g. `::ffff:104.192.136.0/21`).

This PR adds (failing) tests for them, not a fix.

Currently I simply `.add()` and `match()` stripped versions, i.e. I turn them into normal IPv4 first.